### PR TITLE
Remove blank options from dropdown filters

### DIFF
--- a/Datatable/DatatableQuery.php
+++ b/Datatable/DatatableQuery.php
@@ -340,6 +340,7 @@ class DatatableQuery
         $qb->select('DISTINCT('.$key.')');
         $qb->from($this->metadata->getName(), $this->metadata->getTableName());
         $qb->andWhere($qb->expr()->isNotNull($key));
+        $qb->andWhere($qb->expr()->not($qb->expr()->eq($qb->expr()->trim($key), "''")));
         $qb->addOrderBy($key, 'ASC');
         $this->setLeftJoins($qb);
 


### PR DESCRIPTION
Is there an easier way of checking for blank values?
