### PR TITLE
Add moment_locale and check for valid date data

### DIFF
--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -304,7 +304,7 @@
             var moment_locale = {% if moment_locale is defined %}"{{ moment_locale }}"{% else %}"{{ app.request.locale }}"{% endif %};
 
             function render_datetime(data, type, full, localizedFormat) {
-                if (typeof data.timestamp != 'undefined') {
+                if (data && typeof data.timestamp != 'undefined') {
                     moment.lang(moment_locale);
                     return moment.unix(data.timestamp).format(localizedFormat);
                 } else {
@@ -313,7 +313,7 @@
             }
 
             function render_timeago(data, type, full) {
-                if (typeof data.timestamp != 'undefined') {
+                if (data && typeof data.timestamp != 'undefined') {
                     moment.lang(moment_locale);
                     return moment.unix(data.timestamp).fromNow();
                 } else {


### PR DESCRIPTION
Adds a check for the global moment_locale variable, as this may need to be different than the main app locale (en-au vs en for example), so that moment picks up the correct localised date formats.

Also adds a check to make sure that the data exists in the timestamp column before applying the date format.
