### PR TITLE
Update column render function to be raw output

### DIFF
--- a/Resources/views/Column/column.html.twig
+++ b/Resources/views/Column/column.html.twig
@@ -18,9 +18,7 @@
         {% endif %}
 
         {% if column.render %}
-            "render": function(data, type, full) {
-                return {{ column.render|raw }}(data, type, full);
-            },
+            "render": {{ column.render|raw }},
         {% endif %}
     {% endblock %}
 },


### PR DESCRIPTION
Is it okay to make this change?

I'm trying to prepend a dollar sign to a column value through a custom render:
'render' => 'function(data, type, full) { return "$"+data }'

The quotes ensure the dollar is a string value, but they get encoded causing js errors so I need output render as raw.
As render is always going to be a function I figured this was okay but changing things to output raw always makes me paranoid
