### PR TITLE
Add check for parent data when linking to associated item

### DIFF
--- a/Resources/views/Column/link.html.twig
+++ b/Resources/views/Column/link.html.twig
@@ -7,6 +7,13 @@
         var attributes = "";
 
         {% for key, value in column.routeParameters %}
+            {# for association links, check the parent element exists in the data #}
+            {% if '.' in value %}
+                {% set parent = value|split('.')|first %}
+                if (!full.{{ parent }}) {
+                    return '';
+                }
+            {% endif %}
             routeParameters["{{ key }}"] = full.{{ value }};
         {% endfor %}
         {% for key, value in column.routeStaticParameters %}


### PR DESCRIPTION
For example if you have an association to the item "related", and you want to create a link to this item then the route would use the parameter related.id or similar.
This check just ensures that "related" is set in the dataset before retrieving the id.
