### PR TITLE
Add keyup enter event to detect filter changes

### DIFF
--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -146,7 +146,11 @@
                             e.stopPropagation();
                         })
 
-                        $('.dt_columnFilter').on('change', function(){
+                        $('.dt_columnFilter').on('change keyup', function(event){
+                            if (event.type == 'keyup' && event.which != 13) {
+                                return false;
+                            }
+
                             var $this = $(this);
                             var colIndex = $this.closest('th').data('filter-target');
                             var options = [];


### PR DESCRIPTION
It's a bit counterintuitive to have to lose focus on the filter field to trigger the change event to filter the data.
Filtering as you type won't work as the table is constantly reloading and with the loading graphic overlay this can be a pain, but at least this lets you press enter in the filter field to filter the data
