### PR TITLE
Default col searches

### DIFF
--- a/Datatable/View/AbstractDatatableView.php
+++ b/Datatable/View/AbstractDatatableView.php
@@ -140,6 +140,13 @@ abstract class AbstractDatatableView implements DatatableViewInterface
     private $clearStateEnabled = false;
 
     /**
+     * Set clearExistingState
+     *
+     * @var int
+     */
+    private $clearExistingState = false;
+
+    /**
      * Constructor.
      *
      * @param TwigEngine $templating           The templating service
@@ -200,6 +207,7 @@ abstract class AbstractDatatableView implements DatatableViewInterface
         $options['dt_defaultColumnSearches'] = $this->getDefaultColumnSearches();
         $options['dt_stateSaving'] = $this->isStateSaving();
         $options['dt_clearStateEnabled'] = $this->isClearStateEnabled();
+        $options['dt_clearExistingState'] = $this->getClearExistingState();
 
         $stateDuration = $this->getStateDuration();
         if (false !== $stateDuration) {
@@ -586,4 +594,27 @@ abstract class AbstractDatatableView implements DatatableViewInterface
         return $this->clearStateEnabled;
     }
 
+    /**
+     * Set clearExistingState.
+     *
+     * @param boolean $clearExistingState
+     *
+     * @return $this
+     */
+    public function setClearExistingState($clearExistingState)
+    {
+        $this->clearExistingState = (boolean) $clearExistingState;
+
+        return $this;
+    }
+
+    /**
+     * Get clearExistingState.
+     *
+     * @return boolean
+     */
+    public function getClearExistingState()
+    {
+        return $this->clearExistingState;
+    }
 }

--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -177,6 +177,12 @@
                     ]
                 });
 
+                {% if dt_clearExistingState %}
+                    handleStorageItem('remove', 'table');
+                    handleStorageItem('remove', 'firstFilteredCol');
+                    handleStorageItem('remove', 'lastFilteredCol');
+                {% endif %}
+
                 var selector = "#{{ dt_tableId }}";
                 table = $(selector).DataTable(config);
 


### PR DESCRIPTION
Adds:
- defaultColumnSearches: allowing an array of column value pairs to be set in the datatables searchCols param
- clearExistingState: clears the saved table state prior to table load. Useful if you want to link to the table and load a set of default searches as you can override the users existing saved state
