### PR TITLE
Added Expandable column

### DIFF
--- a/Column/ColumnFactory.php
+++ b/Column/ColumnFactory.php
@@ -69,6 +69,9 @@ class ColumnFactory implements ColumnFactoryInterface
             case 'multiselect':
                 $this->column = new MultiSelectColumn($property);
                 break;
+            case 'expandable':
+                $this->column = new ExpandableColumn($property);
+                break;
             default:
                 throw new Exception("The {$name} column is not supported.");
         }

--- a/Column/ExpandableColumn.php
+++ b/Column/ExpandableColumn.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the TommyGNRDatatablesBundle package.
+ *
+ * (c) Tom Corrigan <https://github.com/tommygnr/DatatablesBundle>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace TommyGNR\DatatablesBundle\Column;
+
+use TommyGNR\DatatablesBundle\Column\AbstractColumn as BaseColumn;
+use Exception;
+
+/**
+ * Class ExpandableColumnColumn
+ *
+ */
+class ExpandableColumn extends BaseColumn
+{
+    
+    private $template;
+    
+    /**
+     * Constructor.
+     *
+     * @param null|string $property An entity's property
+     *
+     * @throws Exception
+     */
+    public function __construct($property = null)
+    {
+        
+        if (null != $property) {
+            throw new Exception("The entity's property should be null.");
+        }
+        parent::__construct($property);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassName()
+    {
+        return 'expandable';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        if (array_key_exists('template', $options)) {
+            $this->setTemplate($options['template']);
+        }
+        $options['class'] = 'expandable';
+        parent::setOptions($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaults()
+    {
+        parent::setDefaults();
+        
+        $this->setSortable(false);
+        $this->setSearchable(false);
+        $this->setFilterable(false);
+        $this->setTemplate('return "";');
+        
+    }
+    
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+        return $this;
+    }
+    
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+}

--- a/Datatable/DatatableData.php
+++ b/Datatable/DatatableData.php
@@ -131,6 +131,7 @@ class DatatableData implements DatatableDataInterface
      */
     private function addSelectColumn(ClassMetadata $metadata, $column, $columnTableName = null)
     {
+        if ($column === null) return $this;
         if (in_array($column, $metadata->getFieldNames())) {
             $this->selectColumns[($columnTableName ?: $metadata->getTableName())][] = $column;
         } else {
@@ -208,7 +209,7 @@ class DatatableData implements DatatableDataInterface
             if (strstr($column->getProperty(), '.') !== false) {
                 $array = explode('.', $column->getProperty());
                 $this->setAssociations($array, $this->metadata);
-            } elseif ($column->getProperty() !== null) {
+            } else {
                 // no association found
                 if ($column !== $this->rootEntityIdentifier) {
                     $this->addSelectColumn($this->metadata, $column->getProperty());

--- a/Datatable/DatatableQuery.php
+++ b/Datatable/DatatableQuery.php
@@ -223,6 +223,7 @@ class DatatableQuery
                 //TODO This should be read from server side(PHP) config, not client side
                 $dtColumn = $dtColumns[$key];
                 if ($dtColumn->isSearchable()) {
+                    if ($dtColumn->getProperty() === null) continue;
                     $searchField = $this->allColumns[$key];
                     $orExpr->add($qb->expr()->like($searchField, "?$i"));
                 }

--- a/Resources/views/Column/expandable.html.twig
+++ b/Resources/views/Column/expandable.html.twig
@@ -1,0 +1,15 @@
+{% extends 'TommyGNRDatatablesBundle:Column:column.html.twig' %}
+
+{% block common %}
+    "searchable": {{ column.searchable ? 'true' : 'false' }},
+    "sortable": {{ column.sortable ? 'true' : 'false' }},
+    "visible": {{ column.visible ? 'true' : 'false' }},
+
+    "title": "{{ column.title }}",
+    "class": "{{ column.class }}",
+    "defaultContent": "{{ column.defaultContent }}",
+    "width": "{{ column.width }}",
+    "renderContent": function(data) {
+        {{ column.template|raw }}
+    },
+{% endblock %}

--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -302,6 +302,22 @@
                         location.reload();
                     });
                 {% endif %}
+                
+                $(selector + " tbody").on('click', 'td.expandable', function(){
+                    var tr = $(this).closest('tr');
+                    var row = table.row(tr);
+                    var column = $(this).closest('table').find('th').eq($(this).index());
+                    if (row.child.isShown()) {
+                        row.child.hide();
+                        tr.removeClass('shown');
+                    } else {
+                        var columnIndex = table.column(column).index();
+                        var settingData = table.settings()[0].aoColumns[columnIndex];
+                        tr.addClass('shown');
+                        row.child(settingData.renderContent(row.data())).show();
+                    }
+                })
+                
             });
 
             function getSelectedIds() {


### PR DESCRIPTION
Adds functionality to allow a column which can expand to show further detail. Useful for when there is a lot of data needed to be displayed, but not necessarily at a glance.

It's worth noting that there was an issue present where the indices became offset whenever a column has a null property. Since the system relies on the fact that the column indices remain constant on both the client and server when searching through data, it failed whenever a null property column was present. (I'm not sure how Action columns ever worked?)

I've attempted to solve this by still adding the entry to the allColumns array, but just ignoring it when trying to search for it, or select it. I am not completely certain that this covers all usage scenarios however.