### PR TITLE
Allow multiple association joins

### DIFF
--- a/Datatable/DatatableData.php
+++ b/Datatable/DatatableData.php
@@ -163,11 +163,10 @@ class DatatableData implements DatatableDataInterface
             $targetTableName = $targetMeta->getTableName();
             $targetIdentifiers = $targetMeta->getIdentifierFieldNames();
             $targetRootIdentifier = array_shift($targetIdentifiers);
-            $targetTableAlias = $targetTableName.'_'.$column;
+            $parentTableAlias = $parentTableAlias ?: $metadata->getTableName();
+            $targetTableAlias = $parentTableAlias.'_'.$targetTableName.'_'.$column;
             if (!array_key_exists($targetTableAlias, $this->selectColumns)) {
                 $this->addSelectColumn($targetMeta, $targetRootIdentifier, $targetTableAlias);
-
-                $parentTableAlias = $parentTableAlias ?: $metadata->getTableName();
 
                 $this->addJoin(
                     array(


### PR DESCRIPTION
Previously any assocations that referred to the same table twice would be seen as duplicates, this PR uses the entire table path as the identifier as opposed to just the table and column name.

Admittedly, the aliases get pretty long in the query, but they're at least seen as unique.