### PR TITLE
Boolean support

### DIFF
--- a/Column/AbstractColumn.php
+++ b/Column/AbstractColumn.php
@@ -389,6 +389,11 @@ abstract class AbstractColumn implements ColumnInterface
         return $this;
     }
 
+    public function filterProcess($qb, $field, $alias, $value) {
+      $qb->setParameter($alias, "%".$value."%");
+      return $qb->expr()->like($field, "?$alias");
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Column/BooleanColumn.php
+++ b/Column/BooleanColumn.php
@@ -114,6 +114,12 @@ class BooleanColumn extends BaseColumn
         $this->setFalseLabel(null);
     }
 
+    public function filterProcess($qb, $field, $alias, $value) {
+      $value = $value == "true" ? 1 : 0;
+      $qb->setParameter($alias, $value);
+      return $qb->expr()->eq($field, "?$alias");
+    }
+
     /**
      * Set false icon.
      *

--- a/Datatable/DatatableQuery.php
+++ b/Datatable/DatatableQuery.php
@@ -242,8 +242,8 @@ class DatatableQuery
             if ($dtColumn->isFilterable() && $column['search']['value'] != '') {
                 //TODO This should be read from server side(PHP) config, not client side
                 $searchField = $this->allColumns[$key];
-                $andExpr->add($qb->expr()->like($searchField, "?$i"));
-                $qb->setParameter($i, "%".$column['search']['value']."%");
+                $expression = $dtColumn->filterProcess($qb, $searchField, $i, $column['search']['value']);
+                $andExpr->add($expression);
                 $i++;
             }
         }

--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -213,7 +213,10 @@
 
                 function getSearches( element, settings ) {
                     var dtSearchColIndex = $(element).attr('data-filter-target');
-                    return table.columns(dtSearchColIndex).search();
+                    var searches = table.columns(dtSearchColIndex).search();
+                    if (searches[0] === 'true') searches[0] = true;
+                    if (searches[0] === 'false') searches[0] = false;
+                    return searches;
                 }
 
                 function getFilterOptions(element, json, target, searches) {
@@ -223,7 +226,7 @@
                     var output = '<option value=""></option>';
                     json.columnFilterChoices[target].forEach(function(entry){
                         var selected = '';
-                        if (searches[0] != '' && searches[0] == entry) {
+                        if (searches[0] !== '' && searches[0] == entry) {
                             selected = ' selected="selected"';
                         }
 
@@ -274,11 +277,14 @@
                     }
 
                     if (action == 'get') {
+                      var returnValue = '';
                         if (useLS) {
-                            return JSON.parse(localStorage.getItem(storageKeys[key]));
+                            returnValue = JSON.parse(localStorage.getItem(storageKeys[key]));
                         } else {
-                            return JSON.parse(sessionStorage.getItem(storageKeys[key]));
+                            returnValue = JSON.parse(sessionStorage.getItem(storageKeys[key]));
                         }
+                        if (returnValue === 'true') returnValue = true;
+                        if (returnValue === 'false') returnValue = false;
                     }
 
                     if (action == 'set' && value != 'undefined' && value != null) {
@@ -302,7 +308,7 @@
                         location.reload();
                     });
                 {% endif %}
-                
+
                 $(selector + " tbody").on('click', 'td.expandable', function(){
                     var tr = $(this).closest('tr');
                     var row = table.row(tr);
@@ -317,7 +323,7 @@
                         row.child(settingData.renderContent(row.data())).show();
                     }
                 })
-                
+
             });
 
             function getSelectedIds() {


### PR DESCRIPTION
Fixed filtering by boolean.

Would previously show change 'Yes' to 'true' etc. in the filter options and also not filter anything.

This solution reacts badly on the chance that a field is equal to the string 'true', but since basically everything stringifies booleans (localStorage, datatables.search, HTML keys), I really do not have a solution for this.