### PR TITLE
added datetime to timestamp to normalizer

### DIFF
--- a/Datatable/DateTimeNormalizer.php
+++ b/Datatable/DateTimeNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the TommyGNRDatatablesBundle package.
+ *
+ * (c) Tom Corrigan <https://github.com/tommygnr/DatatablesBundle>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace TommyGNR\DatatablesBundle\Datatable;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use \DateTime;
+
+/**
+ * Class DateTimeNormalizer
+ */
+class DateTimeNormalizer implements NormalizerInterface
+{
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $object->getTimestamp();
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof DateTime) return true;
+        return false;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,13 +3,16 @@ services:
     tommygnr_datatables.serializer.method:
         class: Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer
 
+    tommygnr_datatables.serializer.datetime:
+        class: TommyGNR\DatatablesBundle\Datatable\DateTimeNormalizer
+
     tommygnr_datatables.serializer.encoder.json:
         class: Symfony\Component\Serializer\Encoder\JsonEncoder
 
     tommygnr_datatables.serializer:
         class: Symfony\Component\Serializer\Serializer
         arguments:
-            - [@tommygnr_datatables.serializer.method]
+            - [@tommygnr_datatables.serializer.datetime, @tommygnr_datatables.serializer.method]
             - [@tommygnr_datatables.serializer.encoder.json]
 
     tommygnr_datatables.datatable.view.factory:

--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -372,18 +372,18 @@
             var moment_locale = {% if moment_locale is defined %}"{{ moment_locale }}"{% else %}"{{ app.request.locale }}"{% endif %};
 
             function render_datetime(data, type, full, localizedFormat) {
-                if (data && typeof data.timestamp != 'undefined') {
+                if (data && typeof data != 'undefined') {
                     moment.lang(moment_locale);
-                    return moment.unix(data.timestamp).format(localizedFormat);
+                    return moment.unix(data).format(localizedFormat);
                 } else {
                     return null;
                 }
             }
 
             function render_timeago(data, type, full) {
-                if (data && typeof data.timestamp != 'undefined') {
+                if (data && typeof data != 'undefined') {
                     moment.lang(moment_locale);
-                    return moment.unix(data.timestamp).fromNow();
+                    return moment.unix(data).fromNow();
                 } else {
                     return null;
                 }


### PR DESCRIPTION
In some newer versions, the timezone gets encoded to a very extensive list of transitions, inflating the reponse size massively.

This resolves the issue by only sending the unix timestamp.