### PR TITLE
Filter Seeded should require exact match

### DIFF
--- a/Column/AbstractColumn.php
+++ b/Column/AbstractColumn.php
@@ -416,8 +416,12 @@ abstract class AbstractColumn implements ColumnInterface
     }
 
     public function filterProcess($qb, $field, $alias, $value) {
-      $qb->setParameter($alias, "%".$value."%");
-      return $qb->expr()->like($field, "?$alias");
+        if ($this->isFilterSeeded()) {
+            $qb->setParameter($alias, $value);
+            return $qb->expr()->eq($field, "?$alias");
+        }
+        $qb->setParameter($alias, "%".$value."%");
+        return $qb->expr()->like($field, "?$alias");
     }
 
     /**


### PR DESCRIPTION
Sometimes one value is a substring of another, showing results of both when only one is 'selected'.